### PR TITLE
fix: auto-select SPI CS0/CS1

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,10 +53,6 @@ The project includes GitHub Actions workflows that automatically build ARM64 bin
 - Push to main branch triggers ARM64 cross-compilation
 - Release tags automatically build and upload ARM64 binaries
 
-### Cross-Compilation Notes
-
-- **Code Status**: ✅ All Rust code compiles successfully for ARM64
-- **Dependencies**: ✅ Hardware-specific deps are properly conditional
 - **Platform Separation**: ✅ macOS/Linux incompatibilities resolved
 - **Recommended Method**: Use `cross` (Option 1) for reliable builds
 - **Native Toolchain**: Requires `aarch64-unknown-linux-gnu-gcc` but may have dependency conflicts

--- a/src/config.rs
+++ b/src/config.rs
@@ -51,15 +51,16 @@ pub struct DisplayConfig {
 /// Hardware GPIO pin configuration for e-ink display
 ///
 /// Default pin mapping for Waveshare 4.2" e-ink display on Raspberry Pi Zero 2 W:
-/// - CS (Chip Select): GPIO 8 (Pin 24) - SPI device selection
+/// - CS (Chip Select): GPIO 8 (Pin 24, CE0) - SPI device selection (kernel-controlled by default)
 /// - DC (Data/Command): GPIO 25 (Pin 22) - Data vs command mode  
 /// - RST (Reset): GPIO 17 (Pin 11) - Hardware reset signal
 /// - BUSY: GPIO 24 (Pin 18) - Display busy status indicator
 ///
-/// Override these values if your wiring differs or hardware has conflicts.
+/// You may override `cs_pin` (e.g., to 7 for CE1/SS1/manual CS) if GPIO 8 is damaged.
 #[derive(Debug, Deserialize, Serialize)]
 pub struct HardwareConfig {
-    /// SPI Chip Select pin (default: GPIO 8, Pin 24)
+    /// SPI Chip Select pin (default: GPIO 8, Pin 24, CE0). If not 8, toggled manually.
+    #[serde(default = "default_cs_pin")]
     pub cs_pin: u32,
     /// Data/Command control pin (default: GPIO 25, Pin 22)
     pub dc_pin: u32,
@@ -67,6 +68,10 @@ pub struct HardwareConfig {
     pub rst_pin: u32,
     /// Busy status pin (default: GPIO 24, Pin 18)
     pub busy_pin: u32,
+}
+
+fn default_cs_pin() -> u32 {
+    8
 }
 
 impl Default for Config {

--- a/src/epd4in2b_v2.rs
+++ b/src/epd4in2b_v2.rs
@@ -67,6 +67,16 @@ pub trait SoftwareSpi {
     fn read_byte(&mut self) -> Result<u8, EpdError>;
 }
 
+// Allow Box<dyn SoftwareSpi> to be used as SPI in Epd4in2bV2
+impl<T: SoftwareSpi + ?Sized> SoftwareSpi for Box<T> {
+    fn write_byte(&mut self, data: u8) -> Result<(), EpdError> {
+        (**self).write_byte(data)
+    }
+    fn read_byte(&mut self) -> Result<u8, EpdError> {
+        (**self).read_byte()
+    }
+}
+
 /// Trait for GPIO pin interface
 pub trait GpioPin {
     fn set_high(&mut self) -> Result<(), EpdError>;

--- a/tide-config.toml
+++ b/tide-config.toml
@@ -46,12 +46,14 @@ height = 300
 # Font height in pixels (affects text size and spacing)
 font_height = 20
 
-# Hardware GPIO pin configuration for e-ink display
+ # Hardware GPIO pin configuration for e-ink display
 # Default wiring for Waveshare 4.2" display on Raspberry Pi Zero 2 W
-# Do NOT configure cs_pin here when using hardware SPI; CS is managed by the kernel SPI driver.
-# Only set rst_pin, dc_pin, busy_pin below.
+# cs_pin = 8   # Default: uses spidev0.0 (CE0, GPIO 8, kernel-controlled)
+# cs_pin = 7   # Uses spidev0.1 (CE1, GPIO 7, kernel-controlled)
+# Any other pin → manual GPIO-toggled CS (for custom wiring or damaged CE0/CE1)
 [display.hardware]
-# cs_pin = 8   # REMOVE or comment out this line for hardware SPI
+# cs_pin = 8
+# cs_pin = 7
 rst_pin = 17
 dc_pin = 25
 busy_pin = 24


### PR DESCRIPTION
## Description
Automatically selects hardware SPI device for CE0/CE1, avoids EBUSY by never requesting kernel-controlled CS pins via gpiod, and improves config validation and documentation.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

## Changes Made

- The SPI initialization logic now detects both GPIO 8 (CE0) and GPIO 7 (CE1) as hardware-controlled chip-selects, opening /dev/spidev0.0 or /dev/spidev0.1 as appropriate, and only falls back to manual GPIO-toggled CS for all other pins.
- Adds runtime config validation and warnings if a user attempts to use manual CS on a kernel-controlled pin, preventing confusing EBUSY errors and clarifying expected behavior.
- Updates documentation and example config to clearly explain the new CS pin logic, ensuring users know which pins are hardware-controlled and which require manual toggling, with no behavior change for stock units and full support for “damaged” Pi units using CE1.

## Testing
- [x] Tests pass locally (`cargo test`)
- [ ] New tests added for new functionality
- [x] Manual testing performed
- [x] Tested on target hardware (if applicable)

## Documentation
- [x] Code comments updated
- [ ] README updated (if needed)
- [ ] Configuration documentation updated (if needed)

## Hardware Compatibility
- [x] Tested on Raspberry Pi Zero 2 W
- [ ] E-ink display functionality verified (if applicable)

## Checklist
- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
